### PR TITLE
[feat] Add discord provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ There you have it, a Google OAuth flow with just two routes and one line of code
 
 ## Discord
 
-To setup up a Discord OAuth for your app, `wish` expects the following key and property in either `config/local.js` or `config/custom.js`. For example you can have a development Google `clientId` and `clientSecret` in `config/local.js`
+To setup up a Discord OAuth for your app, `wish` expects the following key and property in either `config/local.js` or `config/custom.js`. For example you can have a development Discord `clientId` and `clientSecret` in `config/local.js`
 
 > Do make sure to get the needed `clientId` and `clientSecret` credentials from Discord. You can see [here](https://discordjs.guide/oauth2) for instructions on how to get those credentials
 
@@ -374,7 +374,7 @@ module.exports = {
 }
 ```
 
-Notice the redirect is a one-line of code and when this action is called, it will redirect to GitHub to begin the OAuth process.
+Notice the redirect is a one-line of code and when this action is called, it will redirect to Discord to begin the OAuth process.
 
 ## The callback
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ wish is the OAuth Sails hook you wish(pun intended) exists for Sails. wish provi
 
 - [GitHub](#github)
 - [Google](#google)
+- [Discord](#discord)
 
 ## Installation
 
@@ -313,6 +314,163 @@ module.exports = {
 ```
 
 There you have it, a Google OAuth flow with just two routes and one line of code each to both redirect to Google and get the OAuth user details.
+
+## Discord
+
+To setup up a Discord OAuth for your app, `wish` expects the following key and property in either `config/local.js` or `config/custom.js`. For example you can have a development Google `clientId` and `clientSecret` in `config/local.js`
+
+> Do make sure to get the needed `clientId` and `clientSecret` credentials from Discord. You can see [here](https://discordjs.guide/oauth2) for instructions on how to get those credentials
+
+```js
+discord: {
+    clientId: 'CLIENT_ID',
+    clientSecret: 'CLIENT_SECRET',
+    redirect: 'http://localhost:1337/auth/callback',
+  },
+```
+
+You can override this value for production in either `custom.js` or in an environment specific `custom.js`. I personally set this up for https://sailscasts.com to override the `local.js` value so I can have 3 environments with 3 different `clientId`, `clientSecret`, and `redirect` values.
+
+```js
+// custom.js
+discord: {
+    clientId: process.env.DISCORD_CLIENT_ID,
+    clientSecret: process.env.DISCORD_CLIENT_SECRET,
+    redirect: 'https://example.com/auth/callback',
+  },
+```
+
+> Notice I am using environment variables as it's best practice not to commit your secret credentials. In the case of `local.js` that's okay because that file is never committed to version control.
+
+### The redirect
+
+A typical flow is to have a button on your website say like "Sign in with Discord" or "Continue with Discord".
+
+Clicking that button should call a redirect route you've set in `routes.js`
+
+```js
+ 'GET /auth/redirect': 'auth/redirect',
+```
+
+Now let's author this `auth/redirect` action:
+
+```js
+module.exports = {
+  friendlyName: 'Redirect',
+
+  description: 'Redirect auth.',
+
+  inputs: {},
+
+  exits: {
+    success: {
+      responseType: 'redirect',
+    },
+  },
+
+  fn: async function () {
+    return sails.wish.provider('discord').redirect()
+  },
+}
+```
+
+Notice the redirect is a one-line of code and when this action is called, it will redirect to GitHub to begin the OAuth process.
+
+## The callback
+
+Note the callback URL we set above that `wish` will callback? Let's also implement that starting from the route in `routes.js`
+
+```js
+'GET /auth/callback': 'auth/callback',
+```
+
+```js
+module.exports = {
+  friendlyName: 'Callback',
+
+  description: 'Callback auth.',
+
+  inputs: {
+    code: {
+      type: 'string',
+      required: true,
+    },
+  },
+
+  exits: {
+    success: {
+      responseType: 'redirect',
+    },
+  },
+
+  fn: async function ({ code }, exits) {
+    const req = this.req
+
+    // Get the Discord user info
+    const discordUser = await sails.wish.provider('discord').user(code)
+    User.findOrCreate(
+      { or: [{ discordId: discordUser.id }, { email: discordUser.email }] },
+      {
+        discordId: discordUser.id,
+        email: discordUser.email,
+        // As at when this was implemented discord doesn't return a name property for the user's name, it only returns username and global_name
+        fullName: discordUser.global_name,
+        discordAvatarUrl: discordUser.avatar || '',
+        discordAccessToken: discordUser.accessToken,
+        discordDiscriminator: discordUser.discriminator || '',
+        emailStatus: discordUser.verified_email ? 'verified' : 'unverified',
+      }
+    ).exec(async (error, user, wasCreated) => {
+      if (error) throw error
+
+      // Checks if the user email has changed since last log in
+      // And then update the email change candidate which will be used be used to prompt the user to update their email
+      if (!wasCreated && user.email !== discordUser.email) {
+        await User.updateOne({ id: user.id }).set({
+          emailChangeCandidate: discordUser.email,
+        })
+      }
+
+      if (!wasCreated && discordUser.verified_email) {
+        await User.updateOne({ id: user.id }).set({
+          emailStatus: 'verified',
+        })
+      }
+
+      if (!wasCreated && user.discordId !== discordUser.id) {
+        await User.updateOne({ id: user.id }).set({
+          emailChangeCandidate: discordUser.email,
+        })
+      }
+
+      if (!wasCreated && user.fullName !== discordUser.name) {
+        await User.updateOne({ id: user.id }).set({
+          fullName: discordUser.global_name,
+        })
+      }
+
+      if (!wasCreated && user.discordAvatarUrl !== discordUser.avatar) {
+        await User.updateOne({ id: user.id }).set({
+          discordAvatarUrl: discordUser.avatar || '',
+        })
+      }
+
+      if (!wasCreated && user.discordAccessToken !== discordUser.accessToken) {
+        await User.updateOne({ id: user.id }).set({
+          discordAccessToken: discordUser.accessToken,
+        })
+      }
+
+      // Modify the active session instance.
+      // (This will be persisted when the response is sent.)
+      req.session.userId = user.id
+      return exits.success('/')
+    })
+  },
+}
+```
+
+There you have it, a Discord OAuth flow with just two routes and one line of code each to both redirect to Discord and get the OAuth user details.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -266,6 +266,7 @@ module.exports = function defineWishHook(sails) {
           } catch (error) {
             throw error
           }
+          break
         case 'discord':
           const discordQueryParams = {
             client_id: clientId,

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"
+  },
+  "dependencies": {
+    "sails-hook-wish": "file:/home/julius-koda/Desktop/JuliusFolder/sails-hook-wish"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,8 +40,5 @@
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"
-  },
-  "dependencies": {
-    "sails-hook-wish": "file:/home/julius-koda/Desktop/JuliusFolder/sails-hook-wish"
   }
 }


### PR DESCRIPTION
### What does this PR do?
This PR adds the discord provider to the sails-wish-hook

### Why is this needed?
No particular grand reason, I just believe that as Sails popularity grows so would it's usecase and having discord Oauth implemented ahead of time would save developers time.

### Related Issues
Closes #8 

### Checklist
- [ ] Code works without errors
- [ ] Docs updated
- [ ] PR follows contribution guidelines

### Demo video
https://github.com/user-attachments/assets/72f06091-ebc2-4c48-9c2a-be2a3ef95136

