### PR TITLE
feat: remove sails-hook-node-fetch peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ wish is the OAuth Sails hook you wish(pun intended) exists for Sails. wish provi
 
 ## Installation
 
-In your Sails project run the below command to install wish and it's `node-fetch` peer-dependency:
+In your Sails project run the below command to install wish:
 
 ```sh
-npm i --save sails-hook-wish @sailscasts/sails-hook-node-fetch
+npm i sails-hook-wish
 ```
+
+> **Note:** This package requires Node.js 18+ as it uses native `fetch`.
 
 ## GitHub
 

--- a/index.js
+++ b/index.js
@@ -132,14 +132,12 @@ module.exports = function defineWishHook(sails) {
       switch (provider) {
         case 'github':
           try {
-            user = await sails.helpers.fetch(
-              sails.config.wish[provider].userUrl,
-              {
-                headers: {
-                  Authorization: `token ${accessToken}`,
-                },
-              }
-            )
+            const response = await fetch(sails.config.wish[provider].userUrl, {
+              headers: {
+                Authorization: `token ${accessToken}`,
+              },
+            })
+            user = await response.json()
           } catch (error) {
             throw error
           }
@@ -147,7 +145,7 @@ module.exports = function defineWishHook(sails) {
         case 'google':
           if (!idToken) throw Error(`${idToken} is not a valid id_token`)
           try {
-            user = await sails.helpers.fetch(
+            const response = await fetch(
               `${sails.config.wish[provider].userUrl}&access_token=${accessToken}`,
               {
                 headers: {
@@ -155,6 +153,7 @@ module.exports = function defineWishHook(sails) {
                 },
               }
             )
+            user = await response.json()
           } catch (error) {
             throw error
           }
@@ -180,7 +179,7 @@ module.exports = function defineWishHook(sails) {
       switch (provider) {
         case 'github':
           try {
-            const response = await sails.helpers.fetch(
+            const tokenResponse = await fetch(
               `${sails.config.wish[provider].tokenUrl}?client_id=${clientId}&client_secret=${clientSecret}&code=${code}`,
               {
                 method: 'POST',
@@ -189,7 +188,8 @@ module.exports = function defineWishHook(sails) {
                 },
               }
             )
-            const { access_token: accessToken } = response
+            const tokenData = await tokenResponse.json()
+            const { access_token: accessToken } = tokenData
             user = await this.userFromToken({ accessToken })
             user.accessToken = accessToken
           } catch (error) {
@@ -209,17 +209,17 @@ module.exports = function defineWishHook(sails) {
           const qs = new URLSearchParams(queryParams)
 
           try {
-            const response = await sails.helpers.fetch(
+            const tokenResponse = await fetch(
               `${sails.config.wish[provider].tokenUrl}?${qs}`,
               {
                 method: 'POST',
                 headers: {
-                  'Content-Type': 'application/x-www-from-urlencoded',
+                  'Content-Type': 'application/x-www-form-urlencoded',
                 },
               }
             )
-
-            const { access_token: accessToken, id_token: idToken } = response
+            const tokenData = await tokenResponse.json()
+            const { access_token: accessToken, id_token: idToken } = tokenData
             user = await this.userFromToken({ accessToken, idToken })
             user.accessToken = accessToken
             user.idToken = idToken

--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
     "prettier": "^2.6.2"
   },
   "peerDependencies": {
-    "@sailscasts/sails-hook-node-fetch": "^0.0.3",
     "sails": "^1.5.2"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Use native fetch (Node.js 18+) instead of sails.helpers.fetch from sails-hook-node-fetch. This simplifies installation and removes an unnecessary dependency.

Closes #10 